### PR TITLE
Remove retired goreportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Work In Progress](https://img.shields.io/badge/Status-Work%20In%20Progress-yellow)](https://guide.unitvectorylabs.com/bestpractices/status/#work-in-progress) [![Go Report Card](https://goreportcard.com/badge/github.com/UnitVectorY-Labs/http-response-collector)](https://goreportcard.com/report/github.com/UnitVectorY-Labs/http-response-collector)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Work In Progress](https://img.shields.io/badge/Status-Work%20In%20Progress-yellow)](https://guide.unitvectorylabs.com/bestpractices/status/#work-in-progress)
 
 # http-response-collector
 


### PR DESCRIPTION
goreportcard.com has been retired. Removing the badge.